### PR TITLE
First pass at adding number of stakers to the contract

### DIFF
--- a/src/StakingRewards.sol
+++ b/src/StakingRewards.sol
@@ -64,6 +64,9 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
     /// @notice Total HLG staked in the contract (includes compounded rewards)
     uint256 public totalStaked;
 
+    /// @notice Count of unique addresses with nonzero stake
+    uint256 public totalStakers;
+
     /// @notice User stake balances (includes original stake + compounded rewards)
     mapping(address => uint256) public balanceOf;
 
@@ -123,6 +126,12 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         uint256 actualAmount = _pullHLG(msg.sender, amount);
         updateUser(msg.sender);
+
+        // Track new staker
+        if (balanceOf[msg.sender] == 0) {
+            totalStakers++;
+        }
+
         balanceOf[msg.sender] += actualAmount;
         totalStaked += actualAmount;
 
@@ -141,8 +150,9 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         balanceOf[msg.sender] = 0;
         userIndexSnapshot[msg.sender] = 0;
+        totalStaked -= userBalance;
         unchecked {
-            totalStaked -= userBalance;
+            totalStakers -= 1;
         }
         HLG.safeTransfer(msg.sender, userBalance);
         emit Unstaked(msg.sender, userBalance);
@@ -158,8 +168,9 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         balanceOf[msg.sender] = 0;
         userIndexSnapshot[msg.sender] = 0;
+        totalStaked -= userBalance;
         unchecked {
-            totalStaked -= userBalance;
+            totalStakers -= 1;
         }
         HLG.safeTransfer(msg.sender, userBalance);
         emit EmergencyExit(msg.sender, userBalance);
@@ -493,6 +504,12 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         _pullHLG(msg.sender, amount);
         updateUser(user);
+
+        // Track new staker
+        if (balanceOf[user] == 0) {
+            totalStakers++;
+        }
+
         balanceOf[user] += amount;
         totalStaked += amount;
 
@@ -535,6 +552,12 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
             uint256 amount = amounts[i];
 
             updateUser(user);
+
+            // Track new staker
+            if (balanceOf[user] == 0) {
+                totalStakers++;
+            }
+
             balanceOf[user] += amount;
             totalStaked += amount;
 
@@ -572,6 +595,12 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         _pullHLG(msg.sender, amount);
         updateUser(user);
+
+        // Track new staker
+        if (balanceOf[user] == 0) {
+            totalStakers++;
+        }
+
         balanceOf[user] += amount;
         totalStaked += amount;
 

--- a/src/lib/UniswapV3TickMath.sol
+++ b/src/lib/UniswapV3TickMath.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.26;
 /**
  * @title UniswapV3TickMath
  * @notice Library for Uniswap V3 tick calculations and range management
- * 
+ *
  * This library provides reusable functions for tick math operations commonly
  * needed when working with Uniswap V3 pools, especially for single-sided
  * liquidity positioning and range calculations.
- * 
+ *
  * Key concepts:
  * - Ticks represent discrete price points in Uniswap V3
  * - Tick spacing determines the granularity of price ranges
@@ -18,17 +18,17 @@ pragma solidity ^0.8.26;
 library UniswapV3TickMath {
     /// @notice Minimum tick value across all Uniswap V3 pools
     int24 internal constant MIN_TICK = -887272;
-    /// @notice Maximum tick value across all Uniswap V3 pools  
+    /// @notice Maximum tick value across all Uniswap V3 pools
     int24 internal constant MAX_TICK = 887272;
-    
+
     /**
      * @notice Calculate optimal tick range for single-sided liquidity provision
-     * 
+     *
      * Single-sided liquidity must be positioned entirely above or below the current
      * price to ensure only one token is required at mint time:
      * - Token0-only: Range above current price (current < tickLower < tickUpper)
      * - Token1-only: Range below current price (tickLower < tickUpper < current)
-     * 
+     *
      * @param currentTick Current pool tick (from slot0)
      * @param tickSpacing Tick spacing for the fee tier
      * @param isToken0Only True for token0-only, false for token1-only
@@ -36,91 +36,66 @@ library UniswapV3TickMath {
      * @return tickLower Lower bound of the range
      * @return tickUpper Upper bound of the range
      */
-    function calculateSingleSidedRange(
-        int24 currentTick,
-        int24 tickSpacing, 
-        bool isToken0Only,
-        int24 rangeSpacings
-    ) external pure returns (int24 tickLower, int24 tickUpper) {
+    function calculateSingleSidedRange(int24 currentTick, int24 tickSpacing, bool isToken0Only, int24 rangeSpacings)
+        external
+        pure
+        returns (int24 tickLower, int24 tickUpper)
+    {
         // Floor current tick to valid tick spacing
         int24 currentFloored = floorToSpacing(currentTick, tickSpacing);
-        
+
         // Calculate min/max ticks for this spacing
         int24 minTick = minTickForSpacing(tickSpacing);
         int24 maxTick = maxTickForSpacing(tickSpacing);
-        
+
         if (isToken0Only) {
             // Token0-only: place range ABOVE current price
             // This ensures current price < tickLower, so only token0 is needed
-            tickLower = clampToBounds(
-                add(currentFloored, oneSpacing(tickSpacing)), 
-                minTick, 
-                maxTick
-            );
-            tickUpper = clampToBounds(
-                add(tickLower, mulSpacing(rangeSpacings, tickSpacing)), 
-                minTick, 
-                maxTick
-            );
+            tickLower = clampToBounds(add(currentFloored, oneSpacing(tickSpacing)), minTick, maxTick);
+            tickUpper = clampToBounds(add(tickLower, mulSpacing(rangeSpacings, tickSpacing)), minTick, maxTick);
         } else {
             // Token1-only: place range BELOW current price
             // This ensures tickUpper < current price, so only token1 is needed
-            tickUpper = clampToBounds(
-                add(currentFloored, -oneSpacing(tickSpacing)), 
-                minTick, 
-                maxTick
-            );
-            tickLower = clampToBounds(
-                add(tickUpper, -mulSpacing(rangeSpacings, tickSpacing)), 
-                minTick, 
-                maxTick
-            );
+            tickUpper = clampToBounds(add(currentFloored, -oneSpacing(tickSpacing)), minTick, maxTick);
+            tickLower = clampToBounds(add(tickUpper, -mulSpacing(rangeSpacings, tickSpacing)), minTick, maxTick);
         }
     }
-    
+
     /**
      * @notice Calculate balanced liquidity range around current price
-     * 
+     *
      * Balanced liquidity straddles the current price, requiring both tokens
      * at mint time but providing active liquidity immediately.
-     * 
+     *
      * @param currentTick Current pool tick
      * @param tickSpacing Tick spacing for the fee tier
      * @param rangeSpacings Number of tick spacings for range width (each side)
      * @return tickLower Lower bound of the range
      * @return tickUpper Upper bound of the range
      */
-    function calculateBalancedRange(
-        int24 currentTick,
-        int24 tickSpacing,
-        int24 rangeSpacings
-    ) external pure returns (int24 tickLower, int24 tickUpper) {
+    function calculateBalancedRange(int24 currentTick, int24 tickSpacing, int24 rangeSpacings)
+        external
+        pure
+        returns (int24 tickLower, int24 tickUpper)
+    {
         int24 currentFloored = floorToSpacing(currentTick, tickSpacing);
         int24 minTick = minTickForSpacing(tickSpacing);
         int24 maxTick = maxTickForSpacing(tickSpacing);
-        
+
         // Symmetric range around current price
-        tickLower = clampToBounds(
-            add(currentFloored, -mulSpacing(rangeSpacings, tickSpacing)), 
-            minTick, 
-            maxTick
-        );
-        tickUpper = clampToBounds(
-            add(currentFloored, mulSpacing(rangeSpacings, tickSpacing)), 
-            minTick, 
-            maxTick
-        );
+        tickLower = clampToBounds(add(currentFloored, -mulSpacing(rangeSpacings, tickSpacing)), minTick, maxTick);
+        tickUpper = clampToBounds(add(currentFloored, mulSpacing(rangeSpacings, tickSpacing)), minTick, maxTick);
     }
-    
+
     /**
      * @notice Get tick spacing for a given fee tier
-     * 
+     *
      * Uniswap V3 uses different tick spacings for different fee tiers:
      * - 100 (0.01%): 1 tick spacing (maximum precision)
-     * - 500 (0.05%): 10 tick spacing  
+     * - 500 (0.05%): 10 tick spacing
      * - 3000 (0.3%): 60 tick spacing
      * - 10000 (1%): 200 tick spacing
-     * 
+     *
      * @param fee Fee tier in basis points
      * @return Tick spacing for the fee tier
      */
@@ -131,12 +106,12 @@ library UniswapV3TickMath {
         if (fee == 10000) return 200;
         revert("unsupported fee tier");
     }
-    
+
     /**
      * @notice Calculate minimum valid tick for a given tick spacing
-     * 
+     *
      * Valid ticks must be multiples of the tick spacing within the global bounds.
-     * 
+     *
      * @param spacing Tick spacing
      * @return Minimum valid tick for this spacing
      */
@@ -145,10 +120,10 @@ library UniswapV3TickMath {
         int24 q = int24((int256(MIN_TICK) / int256(spacing)) * int256(spacing));
         return q;
     }
-    
+
     /**
      * @notice Calculate maximum valid tick for a given tick spacing
-     * 
+     *
      * @param spacing Tick spacing
      * @return Maximum valid tick for this spacing
      */
@@ -156,10 +131,10 @@ library UniswapV3TickMath {
         int24 minTick = minTickForSpacing(spacing);
         return int24(-minTick);
     }
-    
+
     /**
      * @notice Floor a tick to the nearest valid tick for the given spacing
-     * 
+     *
      * @param tick Tick to floor
      * @param spacing Tick spacing
      * @return Floored tick
@@ -171,12 +146,12 @@ library UniswapV3TickMath {
         // rem < 0
         return tick - rem - spacing;
     }
-    
+
     /**
      * @notice Add two int24 values with overflow protection
-     * 
+     *
      * @param a First value
-     * @param b Second value  
+     * @param b Second value
      * @return Sum of a and b
      */
     function add(int24 a, int24 b) internal pure returns (int24) {
@@ -184,10 +159,10 @@ library UniswapV3TickMath {
         require(r >= type(int24).min && r <= type(int24).max, "tick add overflow");
         return int24(r);
     }
-    
+
     /**
      * @notice Multiply tick spacing by count with overflow protection
-     * 
+     *
      * @param count Number of spacings
      * @param spacing Tick spacing
      * @return Product of count and spacing
@@ -197,20 +172,20 @@ library UniswapV3TickMath {
         require(r >= type(int24).min && r <= type(int24).max, "tick mul overflow");
         return int24(r);
     }
-    
+
     /**
      * @notice Return one unit of tick spacing
-     * 
+     *
      * @param spacing Tick spacing
      * @return The spacing value itself
      */
     function oneSpacing(int24 spacing) internal pure returns (int24) {
         return spacing;
     }
-    
+
     /**
      * @notice Clamp a tick value to valid bounds
-     * 
+     *
      * @param tick Tick to clamp
      * @param minTick Minimum allowed tick
      * @param maxTick Maximum allowed tick
@@ -221,23 +196,21 @@ library UniswapV3TickMath {
         if (tick > maxTick) return maxTick;
         return tick;
     }
-    
+
     /**
      * @notice Check if a tick is valid for the given spacing
-     * 
+     *
      * @param tick Tick to validate
      * @param spacing Tick spacing
      * @return True if tick is valid for the spacing
      */
     function isValidTick(int24 tick, int24 spacing) external pure returns (bool) {
-        return tick % spacing == 0 && 
-               tick >= minTickForSpacing(spacing) && 
-               tick <= maxTickForSpacing(spacing);
+        return tick % spacing == 0 && tick >= minTickForSpacing(spacing) && tick <= maxTickForSpacing(spacing);
     }
-    
+
     /**
      * @notice Get the next valid tick above the given tick
-     * 
+     *
      * @param tick Current tick
      * @param spacing Tick spacing
      * @return Next valid tick
@@ -245,17 +218,17 @@ library UniswapV3TickMath {
     function nextTick(int24 tick, int24 spacing) external pure returns (int24) {
         int24 current = floorToSpacing(tick, spacing);
         int24 maxTick = maxTickForSpacing(spacing);
-        
+
         if (current == tick && current < maxTick) {
             return add(current, spacing);
         } else {
             return clampToBounds(add(current, spacing), minTickForSpacing(spacing), maxTick);
         }
     }
-    
+
     /**
      * @notice Get the previous valid tick below the given tick
-     * 
+     *
      * @param tick Current tick
      * @param spacing Tick spacing
      * @return Previous valid tick
@@ -263,7 +236,7 @@ library UniswapV3TickMath {
     function prevTick(int24 tick, int24 spacing) external pure returns (int24) {
         int24 current = floorToSpacing(tick, spacing);
         int24 minTick = minTickForSpacing(spacing);
-        
+
         if (current > minTick) {
             return add(current, -spacing);
         } else {

--- a/test/invariant/StakingRewardsInvariants.t.sol
+++ b/test/invariant/StakingRewardsInvariants.t.sol
@@ -60,6 +60,22 @@ contract StakingRewardsInvariants is StdInvariant, Test {
 
         assertGe(currentIndex, lastIndex, "Invariant violated: globalRewardIndex decreased");
     }
+
+    /// @notice totalStakers should equal the count of users with non-zero balances
+    function invariant_stakerCountAccuracy() public view {
+        address[] memory users = handler.getUsers();
+        uint256 actualStakers = 0;
+
+        for (uint256 i = 0; i < users.length; i++) {
+            if (stakingRewards.balanceOf(users[i]) > 0) {
+                actualStakers++;
+            }
+        }
+
+        assertEq(
+            stakingRewards.totalStakers(), actualStakers, "Invariant violated: totalStakers != count(balanceOf > 0)"
+        );
+    }
 }
 
 /// @title StakingRewardsHandler


### PR DESCRIPTION
### Add totalStakers to StakingRewards + tests


### Summary
- Introduce `totalStakers` to track unique addresses with nonzero stake.
- Add unit tests and an invariant to ensure correctness across all flows.
- All other diffs are formatting-only.

### Changes
- StakingRewards
  - Add `uint256 public totalStakers` (count of addresses with `balanceOf > 0`).
  - Increment on zero→nonzero in: `stake`, `stakeFor` (paused), `batchStakeFor` (paused), `stakeFromDistributor`.
  - Decrement on full exit in: `unstake`, `emergencyExit` (unchecked decrement; safe by invariant and guards).
- Tests
  - test/StakingRewards.t.sol: staker count tests (increment/decrement, multi-user, batch, distributor, stakeFor, pause/unpause, rapid sequences).
  - test/invariant/StakingRewardsInvariants.t.sol: `invariant_stakerCountAccuracy()` ensures `totalStakers == count(balanceOf > 0)`.

### Formatting updates
- Minor whitespace, import ordering, and comment wrapping in scripts and helpers. No functional changes.

### Test plan
- Run `forge test` (unit + invariant).
- Sanity-check: stake/unstake cycles across users and flows; assert `totalStakers` aligns with nonzero balances.

### Risks
- `unchecked` decrement relies on invariant; covered by tests and non-reentrancy. No external permission or reward logic changes.
