### PR TITLE
Fix sandwich attack vulnerability in StakingRewards

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,9 +65,11 @@ LayerZero V2 endpoint verification for all cross-chain messages:
 - **Fee Limits**: Maximum fee percentages to prevent excessive charges
 
 ### Staking Security
-- **Cooldown Period**: 7-day default withdrawal cooldown prevents staking manipulation
-- **Emergency Exit**: Users can always exit, even when paused
+- **Cooldown Period**: 7-day configurable withdrawal cooldown prevents sandwich attacks and staking manipulation
+- **Sandwich Attack Protection**: Users must wait full cooldown period after any stake before unstaking
+- **Emergency Exit**: Users can always exit via `emergencyExit()`, bypassing cooldown for true emergencies
 - **Auto-Compounding**: Rewards automatically compound, preventing loss
+- **Cooldown Configuration**: Owner can adjust cooldown period; changes affect future unstaking behavior
 
 ### Emergency Controls
 - **Pause Functionality**: Owner can pause all major contract functions

--- a/src/StakingRewards.sol
+++ b/src/StakingRewards.sol
@@ -645,9 +645,6 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
         balanceOf[user] += amount;
         totalStaked += amount;
 
-        // Record staking timestamp to enforce cooldown
-        lastStakeTimestamp[user] = block.timestamp;
-
         emit Staked(user, amount);
         emit BoostedStake(msg.sender, user, amount);
     }

--- a/src/StakingRewards.sol
+++ b/src/StakingRewards.sol
@@ -47,6 +47,7 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
     error NotEnoughRewardsAvailable();
     error ActiveStakeExists();
     error RewardTooSmall();
+    error StakingCooldownNotMet();
 
     /* -------------------------------------------------------------------------- */
     /*                                  Storage                                   */
@@ -88,6 +89,12 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
     /// @notice Registry of approved distributors (Merkle drop contracts, quest engines, etc.)
     mapping(address => bool) public isDistributor;
 
+    /// @notice Cooldown period before users can unstake (default: 7 days)
+    uint256 public stakingCooldown;
+
+    /// @notice Tracks when each user last staked tokens
+    mapping(address => uint256) public lastStakeTimestamp;
+
     /* -------------------------------------------------------------------------- */
     /*                                  Events                                    */
     /* -------------------------------------------------------------------------- */
@@ -102,6 +109,7 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
     event EthSwept(uint256 amount, address indexed to);
     event DistributorUpdated(address indexed distributor, bool status);
     event BoostedStake(address indexed distributor, address indexed user, uint256 amount);
+    event StakingCooldownUpdated(uint256 oldCooldown, uint256 newCooldown);
 
     /* -------------------------------------------------------------------------- */
     /*                               Constructor                                  */
@@ -110,6 +118,7 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
         if (_hlg == address(0)) revert ZeroAddress();
         HLG = IERC20(_hlg);
         burnPercentage = 5000; // Default to 50% burn, 50% rewards
+        stakingCooldown = 7 days; // Default to 7-day cooldown
         _pause(); // Start paused until ready
     }
 
@@ -135,6 +144,9 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
         balanceOf[msg.sender] += actualAmount;
         totalStaked += actualAmount;
 
+        // Record staking timestamp to enforce cooldown
+        lastStakeTimestamp[msg.sender] = block.timestamp;
+
         emit Staked(msg.sender, actualAmount);
     }
 
@@ -148,8 +160,14 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
         uint256 userBalance = balanceOf[msg.sender];
         if (userBalance == 0) revert NoStake();
 
+        // Check if cooldown period has passed since last stake (skip if no timestamp set)
+        if (lastStakeTimestamp[msg.sender] != 0 && block.timestamp < lastStakeTimestamp[msg.sender] + stakingCooldown) {
+            revert StakingCooldownNotMet();
+        }
+
         balanceOf[msg.sender] = 0;
         userIndexSnapshot[msg.sender] = 0;
+        lastStakeTimestamp[msg.sender] = 0; // Reset timestamp on unstake
         totalStaked -= userBalance;
         unchecked {
             totalStakers -= 1;
@@ -168,6 +186,7 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         balanceOf[msg.sender] = 0;
         userIndexSnapshot[msg.sender] = 0;
+        lastStakeTimestamp[msg.sender] = 0; // Reset timestamp on emergency exit
         totalStaked -= userBalance;
         unchecked {
             totalStakers -= 1;
@@ -385,6 +404,18 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
         return contractBalance > totalStaked ? contractBalance - totalStaked : 0;
     }
 
+    /**
+     * @notice Check if a user can unstake (cooldown period passed)
+     * @param user Address to check
+     * @return true if user can unstake, false if still in cooldown
+     */
+    function canUnstake(address user) external view returns (bool) {
+        if (balanceOf[user] == 0) return false;
+        // If no timestamp set (owner staking), user can unstake immediately
+        if (lastStakeTimestamp[user] == 0) return true;
+        return block.timestamp >= lastStakeTimestamp[user] + stakingCooldown;
+    }
+
     /* -------------------------------------------------------------------------- */
     /*                                    Admin                                   */
     /* -------------------------------------------------------------------------- */
@@ -424,6 +455,16 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
      */
     function unpause() external onlyOwner {
         _unpause();
+    }
+
+    /**
+     * @notice Set staking cooldown period to prevent sandwich attacks
+     * @param _stakingCooldown New cooldown period in seconds
+     */
+    function setStakingCooldown(uint256 _stakingCooldown) external onlyOwner {
+        uint256 oldCooldown = stakingCooldown;
+        stakingCooldown = _stakingCooldown;
+        emit StakingCooldownUpdated(oldCooldown, _stakingCooldown);
     }
 
     /**
@@ -603,6 +644,9 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
 
         balanceOf[user] += amount;
         totalStaked += amount;
+
+        // Record staking timestamp to enforce cooldown
+        lastStakeTimestamp[user] = block.timestamp;
 
         emit Staked(user, amount);
         emit BoostedStake(msg.sender, user, amount);

--- a/src/StakingRewards.sol
+++ b/src/StakingRewards.sol
@@ -416,6 +416,18 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
         return block.timestamp >= lastStakeTimestamp[user] + stakingCooldown;
     }
 
+    /**
+     * @notice Get remaining cooldown time for a user in seconds
+     * @param user Address to check
+     * @return seconds remaining in cooldown period (0 if can unstake)
+     */
+    function getCooldownTimeRemaining(address user) external view returns (uint256) {
+        if (balanceOf[user] == 0 || lastStakeTimestamp[user] == 0) return 0;
+
+        uint256 cooldownEndTime = lastStakeTimestamp[user] + stakingCooldown;
+        return block.timestamp >= cooldownEndTime ? 0 : cooldownEndTime - block.timestamp;
+    }
+
     /* -------------------------------------------------------------------------- */
     /*                                    Admin                                   */
     /* -------------------------------------------------------------------------- */

--- a/test/StakingRewards.t.sol
+++ b/test/StakingRewards.t.sol
@@ -1833,6 +1833,50 @@ contract StakingRewardsTest is Test {
         assertTrue(stakingRewards.canUnstake(attacker));
     }
 
+    /// @notice Test getCooldownTimeRemaining function returns correct values
+    function testGetCooldownTimeRemaining() public {
+        // Test 1: User with no stake should return 0
+        assertEq(stakingRewards.getCooldownTimeRemaining(alice), 0);
+
+        // Test 2: User stakes and should have cooldown time remaining
+        vm.startPrank(alice);
+        hlg.approve(address(stakingRewards), 10 ether);
+        stakingRewards.stake(10 ether);
+        vm.stopPrank();
+
+        // Should have full cooldown remaining (7 days)
+        assertEq(stakingRewards.getCooldownTimeRemaining(alice), 7 days);
+
+        // Test 3: Advance time partially and check remaining time
+        vm.warp(block.timestamp + 3 days);
+        assertEq(stakingRewards.getCooldownTimeRemaining(alice), 4 days);
+
+        // Test 4: Advance to just before cooldown ends
+        vm.warp(block.timestamp + 4 days - 1);
+        assertEq(stakingRewards.getCooldownTimeRemaining(alice), 1);
+
+        // Test 5: Advance past cooldown period, should return 0
+        vm.warp(block.timestamp + 2);
+        assertEq(stakingRewards.getCooldownTimeRemaining(alice), 0);
+
+        // Test 6: Owner staking should not set cooldown
+        vm.prank(owner);
+        stakingRewards.pause();
+
+        vm.startPrank(owner);
+        hlg.approve(address(stakingRewards), 10 ether);
+        stakingRewards.stakeFor(bob, 10 ether);
+        vm.stopPrank();
+
+        // Bob should have 0 cooldown remaining (owner staking)
+        assertEq(stakingRewards.getCooldownTimeRemaining(bob), 0);
+
+        // Test 7: After unstaking, should return 0
+        vm.prank(alice);
+        stakingRewards.unstake();
+        assertEq(stakingRewards.getCooldownTimeRemaining(alice), 0);
+    }
+
     /* -------------------------------------------------------------------------- */
     /*                            Invariant Helpers                             */
     /* -------------------------------------------------------------------------- */

--- a/test/integration/FeeRouter.t.sol
+++ b/test/integration/FeeRouter.t.sol
@@ -381,6 +381,10 @@ contract FeeRouterTest is Test {
 
         // Full unstake should give original stake + compounded rewards
         uint256 expectedTotal = stakeAmountHLG + expectedRewards;
+
+        // Wait for cooldown period to pass
+        vm.warp(block.timestamp + 7 days + 1);
+
         vm.prank(staker1);
         stakingRewards.unstake();
 


### PR DESCRIPTION
# Fix sandwich attack vulnerability in StakingRewards

## Problem
StakingRewards was vulnerable to sandwich attacks where malicious actors could:
1. Front-run reward distributions with large stakes
2. Capture disproportionate rewards immediately after distribution
3. Unstake immediately to extract value without genuine long-term commitment

This allowed attackers to game the reward system by timing stakes around known distribution events.

## Solution
Implemented a configurable staking cooldown mechanism that prevents immediate unstaking after staking operations:

- **7-day default cooldown** before users can unstake (configurable by owner)
- **Timestamp tracking** for all user-initiated staking actions
- **Smart exemptions** for owner-only administrative functions (`stakeFor`, `batchStakeFor`)
- **Emergency exit** remains available without cooldown restrictions for legitimate emergencies

## Implementation Details

### Core Changes
- Added `stakingCooldown` and `lastStakeTimestamp` storage variables
- Modified `unstake()` to enforce cooldown period with new `StakingCooldownNotMet` error
- Added `setStakingCooldown()` and `canUnstake()` functions for management and queries
- Updated cooldown logic to skip restrictions when `lastStakeTimestamp == 0` (owner staking)

### Staking Function Behavior
- ✅ `stake()` - Sets cooldown timestamp (prevents sandwich attacks)
- ⚪  `stakeFromDistributor()` - No cooldown (admin operations like airdrops)
- ⚪ `stakeFor()` - No cooldown (admin operations like airdrops)
- ⚪ `batchStakeFor()` - No cooldown (admin operations like airdrops)
- ⚪ `emergencyExit()` - Bypasses all cooldown restrictions

### Testing
Added test coverage including:
- Owner vs user staking behavior verification
- Cooldown configuration and zero-cooldown scenarios  
- Emergency exit functionality during cooldown periods
- Mixed staking scenarios and sandwich attack prevention
- Updated existing tests to account for cooldown requirements

## Security Impact
This change makes sandwich attacks economically unviable by requiring capital to be locked for the full cooldown period, while preserving legitimate administrative functionality and user safety through emergency exits.

Closes [#11](https://github.com/zenith-security/2025-09-holograph/issues/11)