### PR TITLE
Fix redundant zero-check in _addRewards function

### DIFF
--- a/src/StakingRewards.sol
+++ b/src/StakingRewards.sol
@@ -349,8 +349,6 @@ contract StakingRewards is Ownable2Step, ReentrancyGuard, Pausable {
      * @param rewardAmount Amount of HLG rewards to distribute to stakers
      */
     function _addRewards(uint256 rewardAmount) internal {
-        if (rewardAmount == 0) return;
-
         uint256 staked = _activeStaked();
         // index bump uses active stake
         globalRewardIndex += (rewardAmount * INDEX_PRECISION) / staked;


### PR DESCRIPTION
# Remove Redundant Zero-Check in _addRewards Function (Issue #8)

## Problem

The `_addRewards()` function contained a redundant zero-check since both callers (`depositAndDistribute` and `addRewards`) already ensure `rewardAmount > 0` before calling it.

## Solution

Removed the unnecessary `if (rewardAmount == 0) return;` check as recommended by the audit.

## Implementation

- **Removed redundant check**: Deleted `if (rewardAmount == 0) return;` from `_addRewards()`
- **All 81 tests passing**: No functionality affected

## Impact

- **Code simplification**: Removes unnecessary logic
- **Gas optimization**: Eliminates redundant check overhead