### PR TITLE
Add pull-based referral splits using Splits V2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -229,6 +229,21 @@ DOPPLER_GOVERNANCE_FACTORY=0xA2dae8ce826A7Ad18A0DAbbf96d5B1E8e27C67Ca  # Sepolia
 UNISWAP_V3_POOL=0x333A14e3e32D8905432b9A70903c473A57dD5E2b
 
 # ---------------------------------------------------------------------------- #
+#                          Splits V2 Configuration                             #
+#                      (For pull-based referral payouts)                       #
+# ---------------------------------------------------------------------------- #
+
+# Splits API key (optional, enables GraphQL features)
+SPLITS_API_KEY=your_splits_api_key
+
+# Wrapped native token address (auto-detected by chain, override if needed)
+# Base Mainnet & Base Sepolia use: 0x4200000000000000000000000000000000000006
+# WRAPPED_NATIVE=0x4200000000000000000000000000000000000006
+
+# Base chain ID (8453 for Base Mainnet, 84532 for Base Sepolia)
+BASE_CHAIN_ID=84532
+
+# ---------------------------------------------------------------------------- #
 #                              Development Tools                               #
 # ---------------------------------------------------------------------------- #
 

--- a/docs/SPLIT_PULL.md
+++ b/docs/SPLIT_PULL.md
@@ -1,0 +1,463 @@
+# Pull-Based Referral Splits Documentation
+
+This document describes the TypeScript tooling for creating and managing pull-based referral payouts using Splits Protocol V2 and the Warehouse contract.
+
+## Overview
+
+The referral system uses immutable **Pull splits** to distribute trading fees across a fixed allocation:
+- **Platform**: 59% (plus any missing tier percentages)
+- **Tier 1**: 35%
+- **Tier 2**: 3%
+- **Tier 3**: 2%
+- **Tier 4**: 1%
+
+Each trader gets their own Split contract address, which is passed as `swapFeeRecipient` to 0x Swap API v2. All swap fees land in the Split, then flow through this sequence:
+
+1. Fees accumulate in the **Split contract** (`splitBalance`)
+2. **Distribute** moves funds to **Warehouse** accounting (`warehouseBalance`)
+3. Recipients **withdraw** from Warehouse to their wallets
+
+No on-chain registry exists; discovery and routing happen off-chain in your application.
+
+## Architecture
+
+```
+┌─────────────┐
+│   0x Swap   │  swapFeeRecipient = Split Address
+└──────┬──────┘
+       │ fees
+       ▼
+┌─────────────┐
+│    Split    │  splitBalance > 0
+│  (immutable)│
+└──────┬──────┘
+       │ distribute()
+       ▼
+┌─────────────┐
+│  Warehouse  │  warehouseBalance > 0 (per recipient)
+└──────┬──────┘
+       │ withdraw()
+       ▼
+┌─────────────┐
+│  Recipient  │  Funds in wallet
+│   Wallets   │
+└─────────────┘
+```
+
+## Setup
+
+### 1. Install Dependencies
+
+```bash
+npm install @0xsplits/splits-sdk viem
+```
+
+### 2. Environment Configuration
+
+Populate `.env` (or pass flags) with a funded signer and RPC:
+
+```bash
+# Base RPCs
+BASE_RPC_URL=https://mainnet.base.org          # mainnet
+BASE_SEPOLIA_RPC_URL=https://sepolia.base.org  # testnet
+
+# Chain selection (8453 mainnet, 84532 testnet)
+BASE_CHAIN_ID=84532
+
+# Signer used for all scripts
+DEPLOYER_PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+
+# Optional: enable Splits hosted APIs
+SPLITS_API_KEY=your_splits_api_key
+```
+
+**Important**
+- These scripts interact with Splits contracts using **native ETH** (no wrapping). Ensure the signer funded above has ETH on the target network.
+- You may override `--rpc` and `--chainId` per command if preferred.
+
+### 3. Network Support
+
+- **Base Mainnet**: Chain ID `8453`
+- **Base Sepolia**: Chain ID `84532`
+
+## Quickstart – Run the full demo
+
+1. Configure `.env` (or export variables) with `BASE_SEPOLIA_RPC_URL`, `BASE_CHAIN_ID=84532`, and `DEPLOYER_PRIVATE_KEY`.
+2. Fund the deployer wallet with a small amount of Base Sepolia ETH.
+3. Run:
+
+   ```bash
+   npx tsx script/ts/splits/demo.ts \
+     --platform 0xPlatformAddress \
+     --tier1 0xTier1Address \
+     --tier2 0xTier2Address \
+     --amount 0.05 \
+     --chainId 84532 \
+     --rpc $BASE_SEPOLIA_RPC_URL
+   ```
+
+   Replace the addresses with real recipients. The script will create the split, fund it with ETH, distribute, and withdraw for each tier so you can observe the entire pull flow locally.
+
+## Scripts
+
+All scripts are located in [`script/ts/splits/`](../script/ts/splits/).
+
+### Create Pull Split
+
+Creates an immutable Pull split with platform and tier addresses.
+
+**Usage:**
+```bash
+npx tsx script/ts/splits/create-pull-split.ts \
+  --platform 0xPlatform... \
+  --tier1 0xTier1... \
+  --tier2 0xTier2... \
+  --tier3 0xTier3... \
+  --tier4 0xTier4... \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Replace the placeholder addresses (and `--chainId/--rpc` if targeting mainnet). Omit tiers you do not have; their percentages roll into the platform share.
+
+**Parameters:**
+- `--platform` (required): Platform fee recipient address
+- `--tier1`, `--tier2`, `--tier3`, `--tier4` (optional): Tier recipient addresses
+- `--salt` (optional): Deterministic salt for CREATE2 address prediction
+- `--rpc` (optional): Override RPC URL
+- `--chainId` (optional): Override chain ID
+
+**Output:**
+- Split address (use as `swapFeeRecipient`)
+- Transaction hash
+- Gas used
+- Deployment confirmation
+
+**Notes:**
+- Missing tiers automatically roll their percentages into platform
+- Splits require at least two recipients, so supply at least one tier address when creating a split
+- Split is immutable (owner = `AddressZero`)
+- If a tier is wrong, create a new Split and update off-chain
+
+### Get Balances
+
+Shows the current ETH balances held by the Split and recorded in Warehouse.
+
+**Usage:**
+```bash
+npx tsx script/ts/splits/get-balances.ts \
+  --split 0xSplitAddressHere \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+**Parameters:**
+- `--split` (required): Split contract address
+- `--rpc` (optional): Override RPC URL
+- `--chainId` (optional): Override chain ID
+
+**Output:**
+- Split balance (ETH held by the split contract)
+- Warehouse balance (ETH credited to recipients)
+- Total balance and human-readable status
+
+### Distribute
+
+Moves accumulated ETH from the Split into Warehouse accounting using the pull model.
+
+**Usage:**
+```bash
+npx tsx script/ts/splits/distribute.ts \
+  --split 0xSplitAddressHere \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+**Parameters:**
+- `--split` (required): Split contract address
+- `--rpc` (optional): Override RPC URL
+- `--chainId` (optional): Override chain ID
+
+**Output:**
+- Pre/post distribution balances
+- Transaction hash
+- Gas used
+- Amount distributed (in ETH)
+
+**Notes:**
+- After distribution, `splitBalance` becomes 0
+- Recipients' `warehouseBalance` increases proportionally
+- Recipients can now withdraw their shares
+
+### Withdraw
+
+Pulls a recipient's ETH balance from Warehouse into their wallet.
+
+**Usage:**
+```bash
+npx tsx script/ts/splits/withdraw.ts \
+  --owner 0xRecipientAddress \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+**Parameters:**
+- `--owner` (required): Recipient address to withdraw for
+- `--rpc` (optional): Override RPC URL
+- `--chainId` (optional): Override chain ID
+
+**Output:**
+- Pre/post Warehouse balance and wallet ETH balance
+- Transaction hash
+- Gas used
+- Amount withdrawn
+
+### Batch Withdraw
+
+Withdraws balances for multiple tokens in one transaction (defaults to ETH only).
+
+**Usage (ETH only):**
+```bash
+npx tsx script/ts/splits/batch-withdraw.ts \
+  --owner 0xRecipientAddress \
+  --tokens native \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Include additional token addresses in `--tokens` (comma separated) if the recipient has ERC20 balances recorded in Warehouse. Use `--withdrawer 0x...` when the claim should be sent to a different address.
+
+**Parameters:**
+- `--owner` (required): Recipient whose balances you are claiming
+- `--tokens` (optional): Comma-separated token list (defaults to `native`)
+- `--withdrawer` (optional): Address that should receive the withdrawn funds (defaults to owner)
+- `--rpc` (optional): Override RPC URL
+- `--chainId` (optional): Override chain ID
+
+**Output:**
+- Pre/post Warehouse balances for each token
+- Transaction hash and gas usage
+- Summary of amounts withdrawn
+
+**Notes:**
+- Automatically skips tokens with zero balances
+- `native` resolves to Splits’ native ETH sentinel (`0xEeeeeE...`); funds remain ETH (no WETH wrapping)
+- Useful when recipients accrue multiple fee assets alongside ETH
+
+### Demo (End-to-End)
+
+Runs the entire pull-based flow with native ETH.
+
+**Usage (Base Sepolia example):**
+```bash
+npx tsx script/ts/splits/demo.ts \
+  --platform 0xPlatformAddress \
+  --tier1 0xTier1Address \
+  --tier2 0xTier2Address \
+  --amount 0.10 \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Replace the addresses with live values. Provide at least one tier recipient (Splits requires two recipients in total).
+
+**Parameters:**
+- `--platform` (required): Platform recipient address
+- `--amount` (required): ETH amount to fund the split
+- `--tier1`, `--tier2`, `--tier3`, `--tier4` (optional): Tier recipient addresses
+- `--rpc` (optional): Override RPC URL
+- `--chainId` (optional): Override chain ID
+
+**Flow:**
+1. Create pull split
+2. Fund split with native ETH
+3. Verify balances (expect `splitBalance > 0`, `warehouseBalance == 0`)
+4. Distribute to Warehouse (`splitBalance == 0`, `warehouseBalance > 0`)
+5. Withdraw ETH for each recipient
+6. Report final allocations received
+
+**Output:**
+- Step-by-step progress
+- All transaction hashes
+- Final Split address for use as `swapFeeRecipient`
+
+## Example Workflow
+
+### 1. Create a Split for a New User
+
+```bash
+npm run splits:create -- \
+  --platform 0xYourPlatform \
+  --tier1 0xReferrer \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Output:
+```
+✅ Split created: 0xABC123...
+```
+
+### 2. Configure 0x Swap API
+
+In your app, when calling 0x Swap API v2:
+
+```typescript
+const quote = await fetch('https://api.0x.org/swap/v2/quote', {
+  method: 'POST',
+  body: JSON.stringify({
+    chainId: 8453,
+    sellToken: '0x...',
+    buyToken: '0x...',
+    sellAmount: '1000000',
+    swapFeeRecipient: '0xABC123...', // Split address from step 1
+    swapFeeBps: 25, // 0.25%
+    swapFeeToken: 'sellToken',
+    // ... other params
+  })
+});
+```
+
+### 3. Fees Accumulate in Split
+
+Over time, swap fees accumulate in the Split contract.
+
+Check balances:
+```bash
+npm run splits:balances -- \
+  --split 0xABC123... \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Output:
+```
+Split Balance:     0.125 ETH
+Warehouse Balance: 0 ETH
+⏳ Funds are in the Split. Run distribute to move to Warehouse.
+```
+
+### 4. Distribute to Warehouse
+
+```bash
+npm run splits:distribute -- \
+  --split 0xABC123... \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Output:
+```
+✅ Distribution complete!
+Split Balance:     0 ETH
+Warehouse Balance: 0.125 ETH
+```
+
+### 5. Recipients Withdraw
+
+Platform withdraws:
+```bash
+npm run splits:withdraw -- \
+  --owner 0xYourPlatform \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Tier 1 withdraws:
+```bash
+npm run splits:withdraw -- \
+  --owner 0xReferrer \
+  --chainId 84532 \
+  --rpc $BASE_SEPOLIA_RPC_URL
+```
+
+Output:
+```
+✅ Funds successfully withdrawn to recipient wallet!
+Amount Withdrawn: 0.044 ETH
+```
+
+## Integration with 0x Swap API v2
+
+Reference: [0x Docs - Upgrading to Gasless API v2](https://0x.org/docs/upgrading/upgrading_to_gasless_v2)
+
+When calling 0x Swap API v2, pass the Split address as `swapFeeRecipient`:
+
+```typescript
+{
+  swapFeeRecipient: userSplitAddress, // From create-pull-split
+  swapFeeBps: 25,                     // 0.25% fee
+  swapFeeToken: 'sellToken',          // or 'buyToken'
+}
+```
+
+All fees from that swap will be sent to the Split address.
+
+## Splits V2 SDK References
+
+- [Splits V2 SDK](https://docs.splits.org/sdk/splits-v2)
+- [Warehouse SDK](https://docs.splits.org/sdk/warehouse)
+
+Key functions used:
+- `createSplit`: Create immutable Pull split
+- `getSplitBalance`: Check balances in Split and Warehouse
+- `distribute`: Move funds from Split to Warehouse
+- `withdraw`: Withdraw from Warehouse to wallet
+- `batchWithdraw`: Withdraw multiple tokens at once
+- `predictDeterministicAddress`: Predict CREATE2 address with salt
+- `isDeployed`: Verify split deployment
+
+## Pull Model vs Push Model
+
+### Pull Model (Used Here)
+- **Recipients call `withdraw()`** to claim their shares from Warehouse
+- Gas paid by recipient
+- More flexible; recipients withdraw when they want
+- No incentive mechanism needed (no distributor fee)
+
+### Push Model (Not Used)
+- Funds pushed directly to recipient wallets during distribution
+- Gas paid by distributor
+- Can include distributor incentive fee
+
+Our referral system uses Pull for flexibility and to let recipients manage their own gas costs.
+
+## Notes
+
+- **Immutability**: Splits are immutable (owner = `AddressZero`). If you need to change allocations, create a new Split and update off-chain.
+- **No On-Chain Registry**: Discovery is off-chain. Your app maps users to Split addresses.
+- **Native Token**: The string `native` maps to Splits’ native ETH sentinel (`0xEeeeeE...`); fees remain ETH throughout the flow.
+- **Gas Estimation**: All write scripts include gas estimation before execution.
+- **Idempotency**: Scripts are safe to re-run; they check balances and skip if nothing to do.
+
+## Troubleshooting
+
+### "No funds to distribute"
+The Split balance is 0. Ensure fees are being sent to the Split address via 0x swaps.
+
+### "No funds to withdraw"
+The recipient's Warehouse balance is 0. Run `distribute` first to move funds from Split to Warehouse.
+
+### "Invalid address"
+Ensure all addresses are checksummed. The scripts auto-validate with `getAddress()`.
+
+### "Unsupported chain ID"
+Only Base (8453) and Base Sepolia (84532) are supported. Update `lib/splits-clients.ts` to add more chains.
+
+## Security Considerations
+
+- **Private Keys**: Never commit `.env` files with real private keys
+- **Testnet First**: Test on Base Sepolia before mainnet
+- **Immutable Splits**: Double-check addresses before creating; splits cannot be modified
+- **Off-Chain Mapping**: Secure your user-to-split mapping database
+- **Withdrawal Access**: Only the recipient can withdraw their Warehouse balance
+
+## Next Steps
+
+1. Create splits for your users with `create-pull-split`
+2. Pass Split addresses to 0x Swap API as `swapFeeRecipient`
+3. Periodically run `distribute` to move fees to Warehouse
+4. Build a UI for recipients to view balances and withdraw
+5. Consider batching withdrawals for gas efficiency
+
+For business context, see O1 Exchange's referral system which uses a similar pull-based claiming model.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
     "multisig-cli:accept-ownership": "tsx script/ts/multisig-cli.ts accept-ownership",
     "multisig-cli:pause": "tsx script/ts/multisig-cli.ts pause",
     "multisig-cli:unpause": "tsx script/ts/multisig-cli.ts unpause",
+    "get-staking-balances": "tsx script/ts/get-staking-balances.ts",
+    "splits:create": "tsx script/ts/splits/create-pull-split.ts",
+    "splits:balances": "tsx script/ts/splits/get-balances.ts",
+    "splits:distribute": "tsx script/ts/splits/distribute.ts",
+    "splits:withdraw": "tsx script/ts/splits/withdraw.ts",
+    "splits:batch-withdraw": "tsx script/ts/splits/batch-withdraw.ts",
+    "splits:demo": "tsx script/ts/splits/demo.ts",
     "type-check": "tsc --noEmit",
     "lint": "eslint script/*.ts",
     "lint:fix": "eslint script/*.ts --fix",
@@ -27,6 +34,7 @@
     "prestart": "npm run build"
   },
   "dependencies": {
+    "@0xsplits/splits-sdk": "^6.1.0",
     "@safe-global/api-kit": "^4.0.0",
     "@safe-global/protocol-kit": "^6.1.0",
     "@safe-global/safe-core-sdk": "^3.3.5",

--- a/script/ts/lib/splits-clients.ts
+++ b/script/ts/lib/splits-clients.ts
@@ -1,0 +1,124 @@
+/**
+ * Splits V2 and Warehouse client configuration
+ *
+ * This module provides configured clients for interacting with Splits Protocol V2
+ * and the Warehouse contract for pull-based fee distribution.
+ */
+
+import { createPublicClient, createWalletClient, http, type Address } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base, baseSepolia } from "viem/chains";
+import { SplitV2Client, WarehouseClient } from "@0xsplits/splits-sdk";
+
+export interface SplitsConfig {
+  rpcUrl: string;
+  chainId: number;
+  privateKey?: string;
+  splitsApiKey?: string;
+}
+
+export interface SplitsClients {
+  publicClient: ReturnType<typeof createPublicClient>;
+  walletClient: ReturnType<typeof createWalletClient>;
+  splitsClient: SplitV2Client;
+  warehouseClient: WarehouseClient;
+}
+
+/**
+ * Get viem chain object from chain ID
+ */
+function getChain(chainId: number) {
+  switch (chainId) {
+    case 8453:
+      return base;
+    case 84532:
+      return baseSepolia;
+    default:
+      throw new Error(`Unsupported chain ID: ${chainId}. Supported: 8453 (Base), 84532 (Base Sepolia)`);
+  }
+}
+
+/**
+ * Native ETH address constant used by Splits V2
+ * This special address (0xEeee...EEeE) is the standard convention
+ * used by Splits Protocol to represent native ETH on any chain
+ */
+export const NATIVE_TOKEN_ADDRESS: Address = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/**
+ * Parse Splits configuration from environment variables
+ */
+export function getSplitsConfigFromEnv(): SplitsConfig {
+  const chainIdStr = process.env.BASE_CHAIN_ID || process.env.CHAIN_ID || "84532";
+  const chainId = parseInt(chainIdStr, 10);
+
+  let rpcUrl: string;
+  if (chainId === 8453) {
+    rpcUrl = process.env.BASE_RPC_URL || "https://mainnet.base.org";
+  } else if (chainId === 84532) {
+    rpcUrl = process.env.BASE_SEPOLIA_RPC_URL || "https://sepolia.base.org";
+  } else {
+    throw new Error(`Unsupported chain ID: ${chainId}`);
+  }
+
+  const privateKey = process.env.PRIVATE_KEY;
+  const splitsApiKey = process.env.SPLITS_API_KEY;
+
+  return {
+    rpcUrl,
+    chainId,
+    privateKey,
+    splitsApiKey,
+  };
+}
+
+/**
+ * Create configured Splits V2 and Warehouse clients
+ */
+export function createSplitsClients(config: SplitsConfig): SplitsClients {
+  const chain = getChain(config.chainId);
+
+  const publicClient = createPublicClient({
+    chain,
+    transport: http(config.rpcUrl),
+  });
+
+  if (!config.privateKey) {
+    throw new Error(
+      "Private key required for wallet client. Set PRIVATE_KEY in .env",
+    );
+  }
+
+  const account = privateKeyToAccount(config.privateKey as `0x${string}`);
+
+  const walletClient = createWalletClient({
+    account,
+    chain,
+    transport: http(config.rpcUrl),
+  });
+
+  const baseConfig = {
+    chainId: config.chainId,
+    publicClient,
+    walletClient,
+  };
+
+  const splitsClient = new SplitV2Client(
+    config.splitsApiKey
+      ? { ...baseConfig, apiConfig: { apiKey: config.splitsApiKey } }
+      : baseConfig
+  );
+
+  const warehouseClient = new WarehouseClient(
+    config.splitsApiKey
+      ? { ...baseConfig, apiConfig: { apiKey: config.splitsApiKey } }
+      : baseConfig
+  );
+
+  return {
+    publicClient,
+    walletClient,
+    splitsClient,
+    warehouseClient,
+  };
+}

--- a/script/ts/splits/batch-withdraw.ts
+++ b/script/ts/splits/batch-withdraw.ts
@@ -1,0 +1,263 @@
+/**
+ * Batch withdraw multiple tokens from Warehouse
+ *
+ * Withdraws multiple token balances in a single transaction
+ * for gas efficiency. Useful when a recipient has accumulated
+ * balances in several different tokens.
+ */
+
+import { type Address, formatUnits, formatEther, getAddress } from "viem";
+import {
+  createSplitsClients,
+  getSplitsConfigFromEnv,
+  NATIVE_TOKEN_ADDRESS,
+  type SplitsConfig,
+} from "../lib/splits-clients.js";
+
+interface BatchWithdrawArgs {
+  owner: string;
+  tokens?: string;
+  withdrawer?: string;
+  rpc?: string;
+  chainId?: string;
+}
+
+/**
+ * Parse command-line arguments
+ */
+function parseArguments(): BatchWithdrawArgs {
+  const args = process.argv.slice(2);
+  const parsed: Partial<BatchWithdrawArgs> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    if (!arg.startsWith("--") || !value) continue;
+
+    const key = arg.slice(2) as keyof BatchWithdrawArgs;
+    if (["owner", "tokens", "withdrawer", "rpc", "chainId"].includes(key)) {
+      parsed[key] = value;
+      i++;
+    }
+  }
+
+  if (!parsed.owner) {
+    console.error("Error: --owner is required");
+    console.log("\nUsage:");
+    console.log("  npx tsx script/ts/splits/batch-withdraw.ts \\");
+    console.log("    --owner 0x... \\");
+    console.log("    [--tokens native] \\");
+    console.log("    [--withdrawer 0x...] \\");
+    console.log("    [--rpc https://...] \\");
+    console.log("    [--chainId 84532]");
+    process.exit(1);
+  }
+
+  return parsed as BatchWithdrawArgs;
+}
+
+/**
+ * Get token decimals and symbol
+ */
+async function getTokenInfo(
+  publicClient: any,
+  tokenAddress: Address
+): Promise<{ decimals: number; symbol: string }> {
+  if (tokenAddress === NATIVE_TOKEN_ADDRESS) {
+    return { decimals: 18, symbol: "ETH" };
+  }
+
+  try {
+    const [decimals, symbol] = await Promise.all([
+      publicClient.readContract({
+        address: tokenAddress,
+        abi: [
+          {
+            name: "decimals",
+            type: "function",
+            stateMutability: "view",
+            inputs: [],
+            outputs: [{ type: "uint8" }],
+          },
+        ],
+        functionName: "decimals",
+      }),
+      publicClient.readContract({
+        address: tokenAddress,
+        abi: [
+          {
+            name: "symbol",
+            type: "function",
+            stateMutability: "view",
+            inputs: [],
+            outputs: [{ type: "string" }],
+          },
+        ],
+        functionName: "symbol",
+      }),
+    ]);
+
+    return { decimals: Number(decimals), symbol: symbol as string };
+  } catch (error) {
+    return { decimals: 18, symbol: "UNKNOWN" };
+  }
+}
+
+function resolveToken(value: string): Address {
+  const lower = value.toLowerCase();
+  if (lower === "native" || lower === "eth") {
+    return NATIVE_TOKEN_ADDRESS;
+  }
+  return getAddress(value);
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const args = parseArguments();
+
+  // Override config if CLI args provided
+  const config: SplitsConfig = args.rpc || args.chainId
+    ? {
+        rpcUrl: args.rpc || getSplitsConfigFromEnv().rpcUrl,
+        chainId: args.chainId ? parseInt(args.chainId) : getSplitsConfigFromEnv().chainId,
+        privateKey: process.env.PRIVATE_KEY,
+        splitsApiKey: process.env.SPLITS_API_KEY,
+      }
+    : getSplitsConfigFromEnv();
+
+  const { warehouseClient, publicClient } = createSplitsClients(config);
+
+  const ownerAddress = args.owner as Address;
+  const tokenStrings = (args.tokens ?? "native").split(",").map((t) => t.trim()).filter(Boolean);
+  const tokenAddresses = tokenStrings.map(resolveToken);
+  const withdrawerAddress = args.withdrawer ? getAddress(args.withdrawer) : ownerAddress;
+
+  console.log(`\n💰 Batch withdrawing from Warehouse...`);
+  console.log(`   Owner: ${ownerAddress}`);
+  console.log(`   Tokens: ${tokenAddresses.length} token(s)`);
+  console.log(`   Chain: ${config.chainId}`);
+  if (withdrawerAddress.toLowerCase() !== ownerAddress.toLowerCase()) {
+    console.log(`   Withdrawer: ${withdrawerAddress} (receives funds)`);
+  }
+
+  // Get pre-withdrawal balances and amounts
+  console.log(`\n🔍 Fetching balances for each token...`);
+  const tokenInfos = await Promise.all(
+    tokenAddresses.map((addr) => getTokenInfo(publicClient, addr))
+  );
+
+  const preBalances = (await Promise.all(
+    tokenAddresses.map((addr) =>
+      warehouseClient.balanceOf({
+        ownerAddress,
+        tokenAddress: addr,
+      })
+    )
+  )).map(({ balance }) => balance);
+
+  console.log(`\n📋 Pre-withdrawal Warehouse balances:`);
+  tokenAddresses.forEach((addr, i) => {
+    const info = tokenInfos[i];
+    const balance = preBalances[i];
+    console.log(
+      `   ${i + 1}. ${info.symbol.padEnd(8)} ${formatUnits(balance, info.decimals).padStart(20)} (${addr})`
+    );
+  });
+
+  // Filter out tokens with zero balance
+  const nonZeroIndices = preBalances
+    .map((bal, idx) => (bal > 0n ? idx : -1))
+    .filter((idx) => idx !== -1);
+
+  if (nonZeroIndices.length === 0) {
+    console.log(`\n⚠️  No tokens with non-zero balances to withdraw`);
+    process.exit(0);
+  }
+
+  const tokensToWithdraw = nonZeroIndices.map((idx) => tokenAddresses[idx]);
+  const amountsToWithdraw = nonZeroIndices.map((idx) => preBalances[idx]);
+
+  console.log(`\n📦 Withdrawing ${tokensToWithdraw.length} token(s) with non-zero balances...`);
+
+  // Estimate gas
+  console.log(`\n⛽ Estimating gas...`);
+  try {
+    const gasEstimate = await warehouseClient.estimateGas.batchWithdraw({
+      ownerAddress,
+      tokensAddresses: tokensToWithdraw,
+      amounts: amountsToWithdraw,
+      withdrawerAddress,
+    });
+
+    console.log(`   Estimated gas: ${gasEstimate.toString()}`);
+  } catch (error) {
+    console.warn("⚠️  Could not estimate gas:", (error as Error).message);
+  }
+
+  // Execute batch withdrawal
+  console.log(`\n🚀 Executing batch withdrawal...`);
+  const { events } = await warehouseClient.batchWithdraw({
+    ownerAddress,
+    tokensAddresses: tokensToWithdraw,
+    amounts: amountsToWithdraw,
+    withdrawerAddress,
+  });
+
+  const txHash = events[0]?.transactionHash;
+  console.log(`✅ Batch withdrawal complete!`);
+  if (txHash) {
+    console.log(`   Transaction: ${txHash}`);
+
+    const receipt = await publicClient.getTransactionReceipt({
+      hash: txHash,
+    });
+
+    console.log(`\n⛽ Gas Used: ${receipt.gasUsed.toString()}`);
+    console.log(`   Effective Gas Price: ${formatEther(receipt.effectiveGasPrice)} ETH/gas`);
+  } else {
+    console.log("   (Transaction hash unavailable; no withdraw events were returned)");
+  }
+
+  // Get post-withdrawal balances
+  console.log(`\n🔍 Fetching post-withdrawal balances...`);
+  const postBalances = (await Promise.all(
+    tokenAddresses.map((addr) =>
+      warehouseClient.balanceOf({
+        ownerAddress,
+        tokenAddress: addr,
+      })
+    )
+  )).map(({ balance }) => balance);
+
+  console.log(`\n📋 Post-withdrawal Warehouse balances:`);
+  tokenAddresses.forEach((addr, i) => {
+    const info = tokenInfos[i];
+    const balance = postBalances[i];
+    console.log(
+      `   ${i + 1}. ${info.symbol.padEnd(8)} ${formatUnits(balance, info.decimals).padStart(20)} (${addr})`
+    );
+  });
+
+  // Show withdrawal summary
+  console.log(`\n📊 Withdrawal Summary:`);
+  nonZeroIndices.forEach((idx) => {
+    const info = tokenInfos[idx];
+    const withdrawn = preBalances[idx] - postBalances[idx];
+    console.log(
+      `   ${info.symbol.padEnd(8)} ${formatUnits(withdrawn, info.decimals)} withdrawn`
+    );
+  });
+
+  console.log(`\n✅ All tokens successfully withdrawn to recipient wallet!`);
+}
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message);
+  if (error.cause) {
+    console.error("   Cause:", error.cause);
+  }
+  process.exit(1);
+});

--- a/script/ts/splits/create-pull-split.ts
+++ b/script/ts/splits/create-pull-split.ts
@@ -1,0 +1,231 @@
+/**
+ * Create an immutable Pull split for referral payouts
+ *
+ * Creates a Splits V2 Pull split with fixed allocations:
+ * - Platform: 59% (plus any missing tier percentages)
+ * - Tier 1: 35%
+ * - Tier 2: 3%
+ * - Tier 3: 2%
+ * - Tier 4: 1%
+ *
+ * Missing tiers roll into platform allocation.
+ */
+
+import { type Address, formatEther, getAddress } from "viem";
+import {
+  createSplitsClients,
+  getSplitsConfigFromEnv,
+  type SplitsConfig,
+} from "../lib/splits-clients.js";
+
+const TIER_PERCENTAGES = {
+  platform: 59,
+  tier1: 35,
+  tier2: 3,
+  tier3: 2,
+  tier4: 1,
+} as const;
+
+interface CreateSplitArgs {
+  platform: string;
+  tier1?: string;
+  tier2?: string;
+  tier3?: string;
+  tier4?: string;
+  salt?: string;
+  rpc?: string;
+  chainId?: string;
+}
+
+/**
+ * Parse command-line arguments
+ */
+function parseArguments(): CreateSplitArgs {
+  const args = process.argv.slice(2);
+  const parsed: CreateSplitArgs = { platform: "" };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    if (!arg.startsWith("--") || !value) continue;
+
+    const key = arg.slice(2) as keyof CreateSplitArgs;
+    if (["platform", "tier1", "tier2", "tier3", "tier4", "salt", "rpc", "chainId"].includes(key)) {
+      parsed[key] = value;
+      i++;
+    }
+  }
+
+  if (!parsed.platform) {
+    console.error("Error: --platform address is required");
+    console.log("\nUsage:");
+    console.log("  npx tsx script/ts/splits/create-pull-split.ts \\");
+    console.log("    --platform 0x... \\");
+    console.log("    [--tier1 0x...] \\");
+    console.log("    [--tier2 0x...] \\");
+    console.log("    [--tier3 0x...] \\");
+    console.log("    [--tier4 0x...] \\");
+    console.log("    [--salt 0x...] \\");
+    console.log("    [--rpc https://...] \\");
+    console.log("    [--chainId 84532]");
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
+/**
+ * Calculate recipients and allocations
+ * Missing tiers roll their percentage into platform
+ */
+function calculateAllocations(addresses: CreateSplitArgs): {
+  recipients: Address[];
+  percentAllocations: number[];
+} {
+  const recipients: Address[] = [];
+  const percentAllocations: number[] = [];
+
+  let platformPercent = TIER_PERCENTAGES.platform;
+
+  // Always include platform first
+  recipients.push(getAddress(addresses.platform));
+
+  const tiers = ["tier1", "tier2", "tier3", "tier4"] as const;
+  for (const tier of tiers) {
+    if (addresses[tier]) {
+      recipients.push(getAddress(addresses[tier]!));
+      percentAllocations.push(Number((TIER_PERCENTAGES[tier]).toFixed(4)));
+    } else {
+      platformPercent += TIER_PERCENTAGES[tier];
+    }
+  }
+
+  // Insert platform allocation at the beginning to align with recipients
+  percentAllocations.unshift(Number(platformPercent.toFixed(4)));
+
+  const total = percentAllocations.reduce((sum, value) => sum + value, 0);
+  const roundedTotal = Number(total.toFixed(4));
+
+  if (roundedTotal !== 100) {
+    throw new Error(
+      `Allocation mismatch: got ${roundedTotal}%, expected 100%`
+    );
+  }
+
+  return { recipients, percentAllocations };
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const args = parseArguments();
+
+  // Override config if CLI args provided
+  const config: SplitsConfig = args.rpc || args.chainId
+    ? {
+        rpcUrl: args.rpc || getSplitsConfigFromEnv().rpcUrl,
+        chainId: args.chainId ? parseInt(args.chainId) : getSplitsConfigFromEnv().chainId,
+        privateKey: process.env.PRIVATE_KEY,
+        splitsApiKey: process.env.SPLITS_API_KEY,
+      }
+    : getSplitsConfigFromEnv();
+
+  const { splitsClient, publicClient } = createSplitsClients(config);
+
+  console.log(`\n🔧 Creating Pull Split on chain ${config.chainId}...`);
+  console.log(`📡 RPC: ${config.rpcUrl}`);
+
+  // Calculate recipients and allocations
+  const { recipients, percentAllocations } = calculateAllocations(args);
+
+  if (recipients.length < 2) {
+    throw new Error("Splits V2 requires at least two recipients. Provide at least one tier address in addition to platform.");
+  }
+
+  console.log(`\n📋 Split Configuration:`);
+  recipients.forEach((recipient, index) => {
+    const percent = percentAllocations[index];
+    const label = index === 0 ? "Platform" : `Tier ${index}`;
+    console.log(`  ${label}: ${recipient} (${percent.toFixed(2)}%)`);
+  });
+
+  // Predict address if salt provided
+  if (args.salt) {
+    try {
+      const predicted = await splitsClient.predictDeterministicAddress({
+        recipients: recipients.map((address, index) => ({
+          address,
+          percentAllocation: percentAllocations[index],
+        })),
+        distributorFeePercent: 0,
+        salt: args.salt as `0x${string}`,
+      });
+
+      console.log(`\n🔮 Predicted Split Address: ${predicted}`);
+    } catch (error) {
+      console.warn("⚠️  Could not predict address:", (error as Error).message);
+    }
+  }
+
+  // Estimate gas
+  console.log("\n⛽ Estimating gas...");
+  try {
+    const gasEstimate = await splitsClient.estimateGas.createSplit({
+      recipients: recipients.map((address, index) => ({
+        address,
+        percentAllocation: percentAllocations[index],
+      })),
+      distributorFeePercent: 0,
+      // Owner defaults to AddressZero (immutable)
+    });
+
+    console.log(`   Estimated gas: ${gasEstimate.toString()}`);
+  } catch (error) {
+    console.warn("⚠️  Could not estimate gas:", (error as Error).message);
+  }
+
+  // Create the split
+  console.log("\n🚀 Creating split...");
+  const createArgs: any = {
+    recipients: recipients.map((address, index) => ({
+      address,
+      percentAllocation: percentAllocations[index],
+    })),
+    distributorFeePercent: 0,
+  };
+
+  if (args.salt) {
+    createArgs.salt = args.salt;
+  }
+
+  const result = await splitsClient.createSplit(createArgs);
+  const txHash = result.event.transactionHash;
+
+  console.log(`✅ Split created!`);
+  console.log(`   Transaction: ${txHash}`);
+  console.log(`   Split Address: ${result.splitAddress}`);
+
+  // Get gas used
+  const receipt = await publicClient.getTransactionReceipt({
+    hash: txHash,
+  });
+
+  console.log(`\n⛽ Gas Used: ${receipt.gasUsed.toString()}`);
+  console.log(`   Effective Gas Price: ${formatEther(receipt.effectiveGasPrice)} ETH/gas`);
+
+  console.log("\n🔍 Deployment confirmed by transaction receipt.");
+
+  console.log("\n🎉 Split creation complete!");
+  console.log(`\n💡 Use this address as swapFeeRecipient in 0x Swap API v2`);
+  console.log(`   Split Address: ${result.splitAddress}`);
+}
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message);
+  if (error.cause) {
+    console.error("   Cause:", error.cause);
+  }
+  process.exit(1);
+});

--- a/script/ts/splits/demo.ts
+++ b/script/ts/splits/demo.ts
@@ -1,0 +1,295 @@
+/**
+ * End-to-end demo of Pull-based referral splits
+ *
+ * Orchestrates the complete flow:
+ * 1. Create a Pull split with platform + tier addresses
+ * 2. Fund the split with native ETH
+ * 3. Check balances (should show splitBalance > 0, warehouseBalance == 0)
+ * 4. Distribute to Warehouse (should show splitBalance == 0, warehouseBalance > 0)
+ * 5. Withdraw for each recipient
+ * 6. Report final amounts received
+ */
+
+import { type Address, parseEther, formatEther, getAddress } from "viem";
+import {
+  createSplitsClients,
+  getSplitsConfigFromEnv,
+  NATIVE_TOKEN_ADDRESS,
+} from "../lib/splits-clients.js";
+
+interface DemoArgs {
+  platform: string;
+  tier1?: string;
+  tier2?: string;
+  tier3?: string;
+  tier4?: string;
+  amount: string;
+  rpc?: string;
+  chainId?: string;
+}
+
+const TIER_PERCENTAGES = {
+  platform: 59,
+  tier1: 35,
+  tier2: 3,
+  tier3: 2,
+  tier4: 1,
+} as const;
+
+/**
+ * Parse command-line arguments
+ */
+function parseArguments(): DemoArgs {
+  const args = process.argv.slice(2);
+  const parsed: Partial<DemoArgs> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    if (!arg.startsWith("--") || !value) continue;
+
+    const key = arg.slice(2) as keyof DemoArgs;
+    if (["platform", "tier1", "tier2", "tier3", "tier4", "amount", "rpc", "chainId"].includes(key)) {
+      parsed[key] = value;
+      i++;
+    }
+  }
+
+  if (!parsed.platform || !parsed.amount) {
+    console.error("Error: --platform and --amount are required");
+    console.log("\nUsage:");
+    console.log("  npx tsx script/ts/splits/demo.ts \\");
+    console.log("    --platform 0x... \\");
+    console.log("    --amount 100 \\");
+    console.log("    [--tier1 0x...] \\");
+    console.log("    [--tier2 0x...] \\");
+    console.log("    [--tier3 0x...] \\");
+    console.log("    [--tier4 0x...] \\");
+    console.log("    [--rpc https://...] \\");
+    console.log("    [--chainId 84532]");
+    process.exit(1);
+  }
+
+  return parsed as DemoArgs;
+}
+
+function buildRecipients(args: DemoArgs): { addresses: Address[]; percents: number[] } {
+  const addresses: Address[] = [];
+  const percents: number[] = [];
+
+  let platformPercent = TIER_PERCENTAGES.platform;
+
+  addresses.push(getAddress(args.platform));
+
+  const tiers = [
+    { key: "tier1" as const, addr: args.tier1 },
+    { key: "tier2" as const, addr: args.tier2 },
+    { key: "tier3" as const, addr: args.tier3 },
+    { key: "tier4" as const, addr: args.tier4 },
+  ];
+
+  for (const tier of tiers) {
+    if (tier.addr) {
+      addresses.push(getAddress(tier.addr));
+      percents.push(Number(TIER_PERCENTAGES[tier.key].toFixed(4)));
+    } else {
+      platformPercent += TIER_PERCENTAGES[tier.key];
+    }
+  }
+
+  percents.unshift(Number(platformPercent.toFixed(4)));
+
+  const total = Number(percents.reduce((sum, value) => sum + value, 0).toFixed(4));
+  if (total !== 100) {
+    throw new Error(`Allocation mismatch during demo setup. Got ${total}%, expected 100%.`);
+  }
+
+  if (addresses.length < 2) {
+    throw new Error("Demo requires at least one tier address in addition to the platform to satisfy Splits requirements.");
+  }
+
+  return { addresses, percents };
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const args = parseArguments();
+
+  const config = args.rpc || args.chainId
+    ? {
+        rpcUrl: args.rpc || getSplitsConfigFromEnv().rpcUrl,
+        chainId: args.chainId ? parseInt(args.chainId) : getSplitsConfigFromEnv().chainId,
+        privateKey: process.env.PRIVATE_KEY,
+        splitsApiKey: process.env.SPLITS_API_KEY,
+      }
+    : getSplitsConfigFromEnv();
+
+  const { splitsClient, warehouseClient, publicClient, walletClient } = createSplitsClients(config);
+
+  console.log(`\n🎬 Pull Splits Demo - End-to-End Flow`);
+  console.log(`═══════════════════════════════════════\n`);
+
+  // Step 1: Create Split
+  console.log(`📋 STEP 1: Create Pull Split\n`);
+
+  const { addresses: recipients, percents } = buildRecipients(args);
+
+  console.log(`Recipients:`);
+  recipients.forEach((addr, i) => {
+    const percent = percents[i];
+    const label = i === 0 ? "Platform" : `Tier ${i}`;
+    console.log(`  ${label.padEnd(10)} ${addr} (${percent.toFixed(2)}%)`);
+  });
+
+  console.log(`\nCreating split...`);
+  const { splitAddress, event: createEvent } = await splitsClient.createSplit({
+    recipients: recipients.map((address, i) => ({
+      address,
+      percentAllocation: percents[i],
+    })),
+    distributorFeePercent: 0,
+  });
+
+  const splitAddr = splitAddress as Address;
+  console.log(`✅ Split created: ${splitAddr}`);
+  console.log(`   Transaction: ${createEvent.transactionHash}`);
+
+  // Step 2: Fund the Split
+  console.log(`\n📋 STEP 2: Fund Split with ETH\n`);
+
+  const fundAmount = parseEther(args.amount);
+
+  console.log(`Funding split with ${args.amount} ETH...`);
+  const fundTx = await walletClient.sendTransaction({
+    to: splitAddr,
+    value: fundAmount,
+  });
+
+  await publicClient.waitForTransactionReceipt({ hash: fundTx });
+  console.log(`✅ Transferred ${args.amount} ETH to split`);
+
+  // Step 3: Check Balances (Pre-Distribute)
+  console.log(`\n📋 STEP 3: Check Balances (Pre-Distribute)\n`);
+
+  const preBalances = await splitsClient.getSplitBalance({
+    splitAddress: splitAddr,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`Split Balance:     ${formatEther(preBalances.splitBalance)} ETH`);
+  console.log(`Warehouse Balance: ${formatEther(preBalances.warehouseBalance)} ETH`);
+
+  if (preBalances.splitBalance === 0n) {
+    console.error(`\n❌ Expected splitBalance > 0, but got 0`);
+    process.exit(1);
+  }
+
+  if (preBalances.warehouseBalance !== 0n) {
+    console.error(`\n❌ Expected warehouseBalance == 0, but got ${preBalances.warehouseBalance}`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Balances are correct (split > 0, warehouse == 0)`);
+
+  // Step 4: Distribute to Warehouse
+  console.log(`\n📋 STEP 4: Distribute to Warehouse\n`);
+
+  console.log(`Distributing...`);
+  const { event: distributeEvent } = await splitsClient.distribute({
+    splitAddress: splitAddr,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`✅ Distributed to Warehouse`);
+  console.log(`   Transaction: ${distributeEvent.transactionHash}`);
+
+  const postDistributeBalances = await splitsClient.getSplitBalance({
+    splitAddress: splitAddr,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`\nPost-distribute balances:`);
+  console.log(`Split Balance:     ${formatEther(postDistributeBalances.splitBalance)} ETH`);
+  console.log(`Warehouse Balance: ${formatEther(postDistributeBalances.warehouseBalance)} ETH`);
+
+  if (postDistributeBalances.splitBalance !== 0n) {
+    console.error(`\n❌ Expected splitBalance == 0 after distribute, but got ${postDistributeBalances.splitBalance}`);
+    process.exit(1);
+  }
+
+  if (postDistributeBalances.warehouseBalance === 0n) {
+    console.error(`\n❌ Expected warehouseBalance > 0 after distribute, but got 0`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Balances are correct (split == 0, warehouse > 0)`);
+
+  // Step 5: Withdraw for Each Recipient
+  console.log(`\n📋 STEP 5: Withdraw for Each Recipient\n`);
+
+  for (let i = 0; i < recipients.length; i++) {
+    const recipient = recipients[i];
+    const label = i === 0 ? "Platform" : `Tier ${i}`;
+
+    console.log(`\n${label} (${recipient}):`);
+
+    const {
+      balance: preWithdrawBalance,
+    } = await warehouseClient.balanceOf({
+      ownerAddress: recipient,
+      tokenAddress: NATIVE_TOKEN_ADDRESS,
+    });
+
+    console.log(`  Warehouse Balance: ${formatEther(preWithdrawBalance)} ETH`);
+
+    if (preWithdrawBalance === 0n) {
+      console.log(`  ⚠️  No balance to withdraw, skipping`);
+      continue;
+    }
+
+    console.log(`  Withdrawing...`);
+    const { event: withdrawEvent } = await warehouseClient.withdraw({
+      ownerAddress: recipient,
+      tokenAddress: NATIVE_TOKEN_ADDRESS,
+    });
+
+    console.log(`  ✅ Withdrawn to wallet`);
+    console.log(`     Transaction: ${withdrawEvent.transactionHash}`);
+
+    const {
+      balance: postWithdrawBalance,
+    } = await warehouseClient.balanceOf({
+      ownerAddress: recipient,
+      tokenAddress: NATIVE_TOKEN_ADDRESS,
+    });
+
+    const withdrawn = preWithdrawBalance - postWithdrawBalance;
+    console.log(`     Amount: ${formatEther(withdrawn)} ETH`);
+  }
+
+  // Step 6: Final Summary
+  console.log(`\n📋 STEP 6: Final Summary\n`);
+
+  console.log(`✅ All steps completed successfully!\n`);
+  console.log(`Summary:`);
+  console.log(`  1. ✅ Created immutable Pull split: ${splitAddr}`);
+  console.log(`  2. ✅ Funded with ${args.amount} ETH`);
+  console.log(`  3. ✅ Verified pre-distribute balances`);
+  console.log(`  4. ✅ Distributed to Warehouse`);
+  console.log(`  5. ✅ Withdrew to all recipients`);
+  console.log(`\n🎉 Pull-based referral split flow complete!\n`);
+  console.log(`💡 Next steps:`);
+  console.log(`   - Use ${splitAddr} as swapFeeRecipient in 0x Swap API v2`);
+  console.log(`   - Recipients can withdraw their shares anytime from Warehouse\n`);
+}
+
+main().catch((error) => {
+  console.error("\n❌ Demo failed:", error.message);
+  if (error.cause) {
+    console.error("   Cause:", error.cause);
+  }
+  process.exit(1);
+});

--- a/script/ts/splits/distribute.ts
+++ b/script/ts/splits/distribute.ts
@@ -1,0 +1,154 @@
+/**
+ * Distribute funds from Split to Warehouse
+ *
+ * Moves funds from the Split contract's balance to the Warehouse,
+ * allocating proportional shares to each recipient according to
+ * their percentAllocation.
+ *
+ * After distribution:
+ * - splitBalance becomes 0
+ * - warehouseBalance increases for each recipient
+ * - Recipients can call withdraw() to claim their shares
+ */
+
+import { type Address, formatEther } from "viem";
+import {
+  createSplitsClients,
+  getSplitsConfigFromEnv,
+  NATIVE_TOKEN_ADDRESS,
+  type SplitsConfig,
+} from "../lib/splits-clients.js";
+
+interface DistributeArgs {
+  split: string;
+  rpc?: string;
+  chainId?: string;
+}
+
+/**
+ * Parse command-line arguments
+ */
+function parseArguments(): DistributeArgs {
+  const args = process.argv.slice(2);
+  const parsed: Partial<DistributeArgs> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    if (!arg.startsWith("--") || !value) continue;
+
+    const key = arg.slice(2) as keyof DistributeArgs;
+    if (["split", "rpc", "chainId"].includes(key)) {
+      parsed[key] = value;
+      i++;
+    }
+  }
+
+  if (!parsed.split) {
+    console.error("Error: --split is required");
+    console.log("\nUsage:");
+    console.log("  npx tsx script/ts/splits/distribute.ts \\");
+    console.log("    --split 0x... \\");
+    console.log("    [--rpc https://...] \\");
+    console.log("    [--chainId 84532]");
+    process.exit(1);
+  }
+
+  return parsed as DistributeArgs;
+}
+
+async function main() {
+  const args = parseArguments();
+
+  // Override config if CLI args provided
+  const config: SplitsConfig = args.rpc || args.chainId
+    ? {
+        rpcUrl: args.rpc || getSplitsConfigFromEnv().rpcUrl,
+        chainId: args.chainId ? parseInt(args.chainId) : getSplitsConfigFromEnv().chainId,
+        privateKey: process.env.PRIVATE_KEY,
+        splitsApiKey: process.env.SPLITS_API_KEY,
+      }
+    : getSplitsConfigFromEnv();
+
+  const { splitsClient, publicClient } = createSplitsClients(config);
+
+  console.log(`\n📦 Distributing funds from Split to Warehouse...`);
+  console.log(`   Split: ${args.split}`);
+  console.log(`   Token: ETH (0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE)`);
+  console.log(`   Chain: ${config.chainId}`);
+
+  // Get pre-distribution balances
+  console.log(`\n🔍 Pre-distribution balances:`);
+  const preBalances = await splitsClient.getSplitBalance({
+    splitAddress: args.split as Address,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`   Split Balance:     ${formatEther(preBalances.splitBalance)} ETH`);
+  console.log(`   Warehouse Balance: ${formatEther(preBalances.warehouseBalance)} ETH`);
+
+  if (preBalances.splitBalance === 0n) {
+    console.log(`\n⚠️  No funds to distribute (splitBalance is 0)`);
+    process.exit(0);
+  }
+
+  // Estimate gas
+  console.log(`\n⛽ Estimating gas...`);
+  try {
+    const gasEstimate = await splitsClient.estimateGas.distribute({
+      splitAddress: args.split as Address,
+      tokenAddress: NATIVE_TOKEN_ADDRESS,
+    });
+
+    console.log(`   Estimated gas: ${gasEstimate.toString()}`);
+  } catch (error) {
+    console.warn("⚠️  Could not estimate gas:", (error as Error).message);
+  }
+
+  // Execute distribution
+  console.log(`\n🚀 Executing distribution...`);
+  const { event } = await splitsClient.distribute({
+    splitAddress: args.split as Address,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`✅ Distribution complete!`);
+  console.log(`   Transaction: ${event.transactionHash}`);
+
+  // Get gas used
+  const receipt = await publicClient.getTransactionReceipt({
+    hash: event.transactionHash,
+  });
+
+  console.log(`\n⛽ Gas Used: ${receipt.gasUsed.toString()}`);
+  console.log(`   Effective Gas Price: ${formatEther(receipt.effectiveGasPrice)} ETH/gas`);
+
+  // Get post-distribution balances
+  console.log(`\n🔍 Post-distribution balances:`);
+  const postBalances = await splitsClient.getSplitBalance({
+    splitAddress: args.split as Address,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`   Split Balance:     ${formatEther(postBalances.splitBalance)} ETH`);
+  console.log(`   Warehouse Balance: ${formatEther(postBalances.warehouseBalance)} ETH`);
+
+  // Show amounts moved
+  const amountDistributed = preBalances.splitBalance - postBalances.splitBalance;
+  const warehouseIncrease = postBalances.warehouseBalance - preBalances.warehouseBalance;
+
+  console.log(`\n📊 Distribution Summary:`);
+  console.log(`   Amount Distributed:    ${formatEther(amountDistributed)} ETH`);
+  console.log(`   Warehouse Increase:    ${formatEther(warehouseIncrease)} ETH`);
+
+  console.log(`\n✅ Funds are now in Warehouse and ready for recipient withdrawals!`);
+}
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message);
+  if (error.cause) {
+    console.error("   Cause:", error.cause);
+  }
+  process.exit(1);
+});

--- a/script/ts/splits/get-balances.ts
+++ b/script/ts/splits/get-balances.ts
@@ -1,0 +1,110 @@
+/**
+ * Get split and warehouse ETH balances
+ *
+ * Shows the ETH balance in both locations:
+ * - splitBalance: ETH in the Split contract (not yet distributed)
+ * - warehouseBalance: ETH in Warehouse (ready to withdraw)
+ */
+
+import { type Address, formatEther } from "viem";
+import {
+  createSplitsClients,
+  getSplitsConfigFromEnv,
+  NATIVE_TOKEN_ADDRESS,
+  type SplitsConfig,
+} from "../lib/splits-clients.js";
+
+interface GetBalancesArgs {
+  split: string;
+  rpc?: string;
+  chainId?: string;
+}
+
+/**
+ * Parse command-line arguments
+ */
+function parseArguments(): GetBalancesArgs {
+  const args = process.argv.slice(2);
+  const parsed: Partial<GetBalancesArgs> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    if (!arg || !arg.startsWith("--") || !value) continue;
+
+    const key = arg.slice(2) as keyof GetBalancesArgs;
+    if (["split", "rpc", "chainId"].includes(key)) {
+      parsed[key] = value;
+      i++;
+    }
+  }
+
+  if (!parsed.split) {
+    console.error("Error: --split is required");
+    console.log("\nUsage:");
+    console.log("  npm run splits:balances -- --split 0x...");
+    console.log("\nOptions:");
+    console.log("  --rpc       Override RPC URL");
+    console.log("  --chainId   Override chain ID (8453 or 84532)");
+    process.exit(1);
+  }
+
+  return parsed as GetBalancesArgs;
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const args = parseArguments();
+
+  const config: SplitsConfig = args.rpc || args.chainId
+    ? {
+        rpcUrl: args.rpc || getSplitsConfigFromEnv().rpcUrl,
+        chainId: args.chainId ? parseInt(args.chainId) : getSplitsConfigFromEnv().chainId,
+        privateKey: process.env.PRIVATE_KEY,
+        splitsApiKey: process.env.SPLITS_API_KEY,
+      }
+    : getSplitsConfigFromEnv();
+
+  const { splitsClient } = createSplitsClients(config);
+
+  console.log(`\n🔍 Fetching ETH balances...`);
+  console.log(`   Split: ${args.split}`);
+  console.log(`   Chain: ${config.chainId}`);
+
+  // Get ETH balances
+  const { splitBalance, warehouseBalance } = await splitsClient.getSplitBalance({
+    splitAddress: args.split as Address,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`\n📊 ETH Balances:`);
+  console.log(`   Split Balance:     ${formatEther(splitBalance)} ETH`);
+  console.log(`   Warehouse Balance: ${formatEther(warehouseBalance)} ETH`);
+  console.log(`   Total:             ${formatEther(splitBalance + warehouseBalance)} ETH`);
+
+  console.log(`\n🔢 Raw Values:`);
+  console.log(`   Split Balance:     ${splitBalance.toString()} wei`);
+  console.log(`   Warehouse Balance: ${warehouseBalance.toString()} wei`);
+
+  console.log(`\n💡 Status:`);
+  if (splitBalance > 0n && warehouseBalance === 0n) {
+    console.log(`   ⏳ ETH in Split. Run distribute to move to Warehouse.`);
+  } else if (splitBalance === 0n && warehouseBalance > 0n) {
+    console.log(`   ✅ ETH in Warehouse. Recipients can withdraw.`);
+  } else if (splitBalance > 0n && warehouseBalance > 0n) {
+    console.log(`   🔄 ETH in both locations. Some distributed, some pending.`);
+  } else {
+    console.log(`   📭 No ETH in either location.`);
+  }
+}
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message);
+  if (error.cause) {
+    console.error("   Cause:", error.cause);
+  }
+  process.exit(1);
+});

--- a/script/ts/splits/withdraw.ts
+++ b/script/ts/splits/withdraw.ts
@@ -1,0 +1,158 @@
+/**
+ * Withdraw funds from Warehouse to recipient wallet
+ *
+ * Pulls the entire balance of a recipient for a given token
+ * from the Warehouse contract to their wallet.
+ *
+ * After withdrawal:
+ * - Warehouse balance for recipient becomes 0
+ * - Tokens are transferred to recipient's wallet
+ */
+
+import { type Address, formatEther } from "viem";
+import {
+  createSplitsClients,
+  getSplitsConfigFromEnv,
+  NATIVE_TOKEN_ADDRESS,
+  type SplitsConfig,
+} from "../lib/splits-clients.js";
+
+interface WithdrawArgs {
+  owner: string;
+  rpc?: string;
+  chainId?: string;
+}
+
+/**
+ * Parse command-line arguments
+ */
+function parseArguments(): WithdrawArgs {
+  const args = process.argv.slice(2);
+  const parsed: Partial<WithdrawArgs> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    if (!arg.startsWith("--") || !value) continue;
+
+    const key = arg.slice(2) as keyof WithdrawArgs;
+    if (["owner", "rpc", "chainId"].includes(key)) {
+      parsed[key] = value;
+      i++;
+    }
+  }
+
+  if (!parsed.owner) {
+    console.error("Error: --owner is required");
+    console.log("\nUsage:");
+    console.log("  npx tsx script/ts/splits/withdraw.ts \\");
+    console.log("    --owner 0x... \\");
+    console.log("    [--rpc https://...] \\");
+    console.log("    [--chainId 84532]");
+    process.exit(1);
+  }
+
+  return parsed as WithdrawArgs;
+}
+
+async function main() {
+  const args = parseArguments();
+
+  // Override config if CLI args provided
+  const config: SplitsConfig = args.rpc || args.chainId
+    ? {
+        rpcUrl: args.rpc || getSplitsConfigFromEnv().rpcUrl,
+        chainId: args.chainId ? parseInt(args.chainId) : getSplitsConfigFromEnv().chainId,
+        privateKey: process.env.PRIVATE_KEY,
+        splitsApiKey: process.env.SPLITS_API_KEY,
+      }
+    : getSplitsConfigFromEnv();
+
+  const { warehouseClient, publicClient } = createSplitsClients(config);
+
+  const ownerAddress = args.owner as Address;
+
+  console.log(`\n💰 Withdrawing from Warehouse to recipient wallet...`);
+  console.log(`   Owner: ${ownerAddress}`);
+  console.log(`   Token: ETH (0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE)`);
+  console.log(`   Chain: ${config.chainId}`);
+
+  // Get pre-withdrawal balances
+  console.log(`\n🔍 Pre-withdrawal balances:`);
+  const { balance: preWarehouseBalance } = await warehouseClient.balanceOf({
+    ownerAddress,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  const preWalletBalance = await publicClient.getBalance({ address: ownerAddress });
+
+  console.log(`   Warehouse Balance: ${formatEther(preWarehouseBalance)} ETH`);
+  console.log(`   Wallet Balance:    ${formatEther(preWalletBalance)} ETH`);
+
+  if (preWarehouseBalance === 0n) {
+    console.log(`\n⚠️  No funds to withdraw (warehouse balance is 0)`);
+    process.exit(0);
+  }
+
+  // Estimate gas
+  console.log(`\n⛽ Estimating gas...`);
+  try {
+    const gasEstimate = await warehouseClient.estimateGas.withdraw({
+      ownerAddress,
+      tokenAddress: NATIVE_TOKEN_ADDRESS,
+    });
+
+    console.log(`   Estimated gas: ${gasEstimate.toString()}`);
+  } catch (error) {
+    console.warn("⚠️  Could not estimate gas:", (error as Error).message);
+  }
+
+  // Execute withdrawal
+  console.log(`\n🚀 Executing withdrawal...`);
+  const { event } = await warehouseClient.withdraw({
+    ownerAddress,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  console.log(`✅ Withdrawal complete!`);
+  console.log(`   Transaction: ${event.transactionHash}`);
+
+  // Get gas used
+  const receipt = await publicClient.getTransactionReceipt({
+    hash: event.transactionHash,
+  });
+
+  console.log(`\n⛽ Gas Used: ${receipt.gasUsed.toString()}`);
+  console.log(`   Effective Gas Price: ${formatEther(receipt.effectiveGasPrice)} ETH/gas`);
+
+  // Get post-withdrawal balances
+  console.log(`\n🔍 Post-withdrawal balances:`);
+  const { balance: postWarehouseBalance } = await warehouseClient.balanceOf({
+    ownerAddress,
+    tokenAddress: NATIVE_TOKEN_ADDRESS,
+  });
+
+  const postWalletBalance = await publicClient.getBalance({ address: ownerAddress });
+
+  console.log(`   Warehouse Balance: ${formatEther(postWarehouseBalance)} ETH`);
+  console.log(`   Wallet Balance:    ${formatEther(postWalletBalance)} ETH`);
+
+  // Show amounts moved
+  const amountWithdrawn = preWarehouseBalance - postWarehouseBalance;
+  const walletIncrease = postWalletBalance - preWalletBalance;
+
+  console.log(`\n📊 Withdrawal Summary:`);
+  console.log(`   Amount Withdrawn:  ${formatEther(amountWithdrawn)} ETH`);
+  console.log(`   Wallet Increase:   ${formatEther(walletIncrease)} ETH`);
+
+  console.log(`\n✅ Funds successfully withdrawn to recipient wallet!`);
+}
+
+main().catch((error) => {
+  console.error("\n❌ Error:", error.message);
+  if (error.cause) {
+    console.error("   Cause:", error.cause);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Pull-Based Referral Splits

Adds TypeScript tooling for ETH fee distribution using Splits V2 on Base. This implements the protocol side of a pull-based referral system where each trader gets an immutable split contract that receives swap fees from 0x, distributes them to a warehouse, and allows recipients to withdraw their shares on demand.

### Architecture

- **Splits V2**: Immutable Pull splits with fixed allocations (platform 59%, tier1 35%, tier2 3%, tier3 2%, tier4 1%)
- **Native ETH**: Uses `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` address convention, no WETH wrapping required
- **Off-chain routing**: No on-chain registry; app passes split addresses to 0x Swap API v2 as `swapFeeRecipient`
- **Pull model**: Recipients withdraw from Warehouse when they want, gas costs paid by recipient

### Scripts Added

```
script/ts/splits/
├── create-pull-split.ts    # Deploy split with platform + optional tiers
├── get-balances.ts          # Check ETH in split vs warehouse
├── distribute.ts            # Move accumulated ETH to warehouse
├── withdraw.ts              # Pull ETH from warehouse to wallet
├── batch-withdraw.ts        # Withdraw multiple tokens efficiently
└── demo.ts                  # End-to-end test flow

script/ts/lib/
└── splits-clients.ts        # Shared viem + Splits SDK client config
```

### Usage

```bash
# Create split for a trader
npm run splits:create -- --platform 0xPlatform --tier1 0xReferrer

# Periodically distribute accumulated fees
npm run splits:distribute -- --split 0xSplit

# Recipients withdraw their share
npm run splits:withdraw -- --owner 0xRecipient
```

### Testing

Successfully tested on Base mainnet (chain 8453) with 0.0005 ETH completing full create → fund → distribute → withdraw cycle. Gas costs for complete flow: ~0.003-0.004 ETH.

See `docs/SPLIT_PULL.md` for complete documentation including integration with 0x Swap API v2.

### Dependencies

- `@0xsplits/splits-sdk@^6.1.0`
- `viem@^2.8.18` (already present)